### PR TITLE
Legg til enkel hovedbokscanner med GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # Hovedbokscanner
-Scanner hovedbok
+
+Et enkelt verktøy som analyserer en hovedbok i Excel-format og peker på
+forhold som kan være interessante for en revisor.
+
+## Installasjon
+
+```bash
+pip install -r requirements.txt
+```
+
+## Bruk
+
+Kjør GUI-appen:
+
+```bash
+python app.py
+```
+
+Programmet bruker `pandas` til å lese Excel-filen. Resultatet viser antall
+funn for hver kontroll, som manglende beskrivelser, store beløp og poster i
+helger.
+
+## Tester
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+"""En enkel GUI-applikasjon for å skanne en hovedbok.
+
+GUI-et er bygget med PyQt5. Programmet forsøker å lese en Excel-fil ved hjelp
+av pandas dersom biblioteket er tilgjengelig. Resultatet fra skanningen
+presenteres som antall funn i et tekstfelt.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import List
+
+from PyQt5 import QtWidgets  # type: ignore
+
+try:  # pragma: no cover - valgfri avhengighet
+    import pandas as pd
+except Exception:  # pragma: no cover
+    pd = None
+
+from scanner import scan_all
+
+
+class MainWindow(QtWidgets.QWidget):
+    """Hovedvindu for programmet."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Hovedbokscanner")
+        layout = QtWidgets.QVBoxLayout()
+
+        self.button = QtWidgets.QPushButton("Åpne hovedbok")
+        self.button.clicked.connect(self.open_file)
+        layout.addWidget(self.button)
+
+        self.text = QtWidgets.QTextEdit()
+        self.text.setReadOnly(True)
+        layout.addWidget(self.text)
+
+        self.setLayout(layout)
+
+    def open_file(self) -> None:
+        """Åpne filvelger og analyser valgt fil."""
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Velg Excel-fil", "", "Excel filer (*.xlsx *.xlsm)"
+        )
+        if not path:
+            return
+        if pd is None:
+            self.text.setPlainText("pandas er ikke installert.")
+            return
+        try:
+            df = pd.read_excel(path)
+        except Exception as exc:  # pragma: no cover - GUI feilhåndtering
+            self.text.setPlainText(f"Kunne ikke lese filen: {exc}")
+            return
+        rows: List[dict] = df.to_dict(orient="records")
+        results = scan_all(rows)
+        lines = [f"{navn}: {len(funn)} funn" for navn, funn in results.items()]
+        self.text.setPlainText("\n".join(lines))
+
+
+def main() -> None:
+    app = QtWidgets.QApplication(sys.argv)
+    win = MainWindow()
+    win.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI inngang
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+openpyxl
+PyQt5

--- a/scanner.py
+++ b/scanner.py
@@ -1,0 +1,85 @@
+"""Funksjoner for å analysere en hovedbok.
+
+Dette modul inneholder grunnleggende søk som typisk kan være nyttige for
+en revisor. Hovedboken forventes representert som en liste med ordbøker
+med minst følgende nøkler:
+
+* ``Dato`` – ISO-formatert dato ``YYYY-MM-DD``.
+* ``Beløp`` – numerisk beløp.
+* ``Beskrivelse`` – tekstlig forklaring.
+* ``Bilagsnummer`` – identifikator for bilaget.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+Entry = Dict[str, Any]
+Ledger = List[Entry]
+
+
+def scan_missing_description(rows: Ledger) -> Ledger:
+    """Returner alle rader uten beskrivelse."""
+    result: Ledger = []
+    for r in rows:
+        value = r.get("Beskrivelse")
+        if value is None or not str(value).strip():
+            result.append(r)
+    return result
+
+
+def scan_large_amounts(rows: Ledger, threshold: float = 100_000) -> Ledger:
+    """Returner rader der absoluttbeløpet er større enn eller lik terskelen."""
+    result: Ledger = []
+    for r in rows:
+        try:
+            amount = float(r.get("Beløp", 0))
+        except (TypeError, ValueError):
+            continue
+        if abs(amount) >= threshold:
+            result.append(r)
+    return result
+
+
+def scan_weekend_entries(rows: Ledger) -> Ledger:
+    """Finn rader som er bokført i helger."""
+    result: Ledger = []
+    for r in rows:
+        date_value = r.get("Dato")
+        if not date_value:
+            continue
+        try:
+            dt = datetime.fromisoformat(str(date_value))
+        except ValueError:
+            continue
+        if dt.weekday() >= 5:  # 5=lørdag, 6=søndag
+            result.append(r)
+    return result
+
+
+def scan_duplicate_voucher(rows: Ledger) -> Ledger:
+    """Identifiser dupliserte bilagsnummer."""
+    seen: Dict[Any, Entry] = {}
+    duplicates: Ledger = []
+    for r in rows:
+        key = r.get("Bilagsnummer")
+        if key in seen:
+            duplicates.append(r)
+            first = seen[key]
+            if first is not None:
+                duplicates.append(first)
+                seen[key] = None  # marker at første allerede lagt til
+        else:
+            seen[key] = r
+    return duplicates
+
+
+def scan_all(rows: Ledger, threshold: float = 100_000) -> Dict[str, Ledger]:
+    """Kjør alle kontroller og returner et resultatsett."""
+    return {
+        "Manglende beskrivelse": scan_missing_description(rows),
+        "Store beløp": scan_large_amounts(rows, threshold),
+        "Helgeposter": scan_weekend_entries(rows),
+        "Dupliserte bilagsnummer": scan_duplicate_voucher(rows),
+    }

--- a/test_scanner.py
+++ b/test_scanner.py
@@ -1,0 +1,73 @@
+import pytest
+
+from scanner import (
+    scan_all,
+    scan_duplicate_voucher,
+    scan_large_amounts,
+    scan_missing_description,
+    scan_weekend_entries,
+)
+
+
+def example_rows():
+    return [
+        {
+            "Dato": "2024-01-01",
+            "Beløp": 50_000,
+            "Beskrivelse": "",
+            "Bilagsnummer": 1,
+        },
+        {
+            "Dato": "2024-01-06",
+            "Beløp": 200_000,
+            "Beskrivelse": "Kjøp",
+            "Bilagsnummer": 2,
+        },
+        {
+            "Dato": "2024-01-07",
+            "Beløp": -150_000,
+            "Beskrivelse": None,
+            "Bilagsnummer": 2,
+        },
+        {
+            "Dato": "2024-01-02",
+            "Beløp": 1_000,
+            "Beskrivelse": "Salg",
+            "Bilagsnummer": 3,
+        },
+    ]
+
+
+def test_scan_missing_description():
+    rows = example_rows()
+    result = scan_missing_description(rows)
+    assert len(result) == 2
+
+
+def test_scan_large_amounts():
+    rows = example_rows()
+    result = scan_large_amounts(rows, threshold=100_000)
+    assert len(result) == 2
+
+
+def test_scan_weekend_entries():
+    rows = example_rows()
+    result = scan_weekend_entries(rows)
+    assert len(result) == 2
+
+
+def test_scan_duplicate_voucher():
+    rows = example_rows()
+    result = scan_duplicate_voucher(rows)
+    assert len(result) == 2
+
+
+def test_scan_all_combines_results():
+    rows = example_rows()
+    result = scan_all(rows, threshold=100_000)
+    assert {key: len(val) for key, val in result.items()} == {
+        "Manglende beskrivelse": 2,
+        "Store beløp": 2,
+        "Helgeposter": 2,
+        "Dupliserte bilagsnummer": 2,
+    }


### PR DESCRIPTION
## Sammendrag
- Legg til modul for å analysere hovedbøker med kontroller for manglende beskrivelse, store beløp, helgeposter og dupliserte bilagsnummer
- Opprett PyQt5-basert GUI som laster Excel-filer og viser antall funn per kontroll
- Dokumenter installasjon, bruk og tester i README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57f7e14388328beb51e8cf66b3acd